### PR TITLE
Iter8

### DIFF
--- a/cmd/agent/main_test.go
+++ b/cmd/agent/main_test.go
@@ -8,61 +8,43 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSendMetricJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+
+		var m Metrics
+		err = json.Unmarshal(body, &m)
+		assert.NoError(t, err)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(m)
+	}))
+	defer ts.Close()
+
+	serverAddress = &ts.URL
+
 	t.Run("send gauge metric", func(t *testing.T) {
-		value := 123.456
+		val := 123.456
 		metric := Metrics{
 			ID:    "TestGauge",
 			MType: "gauge",
-			Value: &value,
+			Value: &val,
 		}
-
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "/update/", r.URL.Path)
-			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
-			body, err := io.ReadAll(r.Body)
-			require.NoError(t, err)
-
-			var got Metrics
-			err = json.Unmarshal(body, &got)
-			require.NoError(t, err)
-
-			assert.Equal(t, metric.ID, got.ID)
-			assert.Equal(t, metric.MType, got.MType)
-			assert.Equal(t, *metric.Value, *got.Value)
-		}))
-		defer server.Close()
-
-		*serverAddress = server.URL[len("http://"):]
 		sendMetricJSON(metric)
 	})
 
 	t.Run("send counter metric", func(t *testing.T) {
-		count := int64(5)
+		delta := int64(42)
 		metric := Metrics{
 			ID:    "TestCounter",
 			MType: "counter",
-			Delta: &count,
+			Delta: &delta,
 		}
-
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "/update/", r.URL.Path)
-			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
-			body, err := io.ReadAll(r.Body)
-			require.NoError(t, err)
-			var got Metrics
-			err = json.Unmarshal(body, &got)
-			require.NoError(t, err)
-			assert.Equal(t, metric.ID, got.ID)
-			assert.Equal(t, metric.MType, got.MType)
-			assert.Equal(t, *metric.Delta, *got.Delta)
-		}))
-		defer server.Close()
-
-		*serverAddress = server.URL[len("http://"):]
 		sendMetricJSON(metric)
 	})
 }

--- a/cmd/agent/main_test.go
+++ b/cmd/agent/main_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendMetricJSON(t *testing.T) {
+	t.Run("send gauge metric", func(t *testing.T) {
+		value := 123.456
+		metric := Metrics{
+			ID:    "TestGauge",
+			MType: "gauge",
+			Value: &value,
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/update/", r.URL.Path)
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+
+			var got Metrics
+			err = json.Unmarshal(body, &got)
+			require.NoError(t, err)
+
+			assert.Equal(t, metric.ID, got.ID)
+			assert.Equal(t, metric.MType, got.MType)
+			assert.Equal(t, *metric.Value, *got.Value)
+		}))
+		defer server.Close()
+
+		*serverAddress = server.URL[len("http://"):]
+		sendMetricJSON(metric)
+	})
+
+	t.Run("send counter metric", func(t *testing.T) {
+		count := int64(5)
+		metric := Metrics{
+			ID:    "TestCounter",
+			MType: "counter",
+			Delta: &count,
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/update/", r.URL.Path)
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			var got Metrics
+			err = json.Unmarshal(body, &got)
+			require.NoError(t, err)
+			assert.Equal(t, metric.ID, got.ID)
+			assert.Equal(t, metric.MType, got.MType)
+			assert.Equal(t, *metric.Delta, *got.Delta)
+		}))
+		defer server.Close()
+
+		*serverAddress = server.URL[len("http://"):]
+		sendMetricJSON(metric)
+	})
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kosta324/metrics.git/internal/handlers"
 	"github.com/kosta324/metrics.git/internal/logger"
 	"github.com/kosta324/metrics.git/internal/storage"
+	"github.com/kosta324/metrics.git/internal/zipper"
 	"go.uber.org/zap"
 )
 
@@ -39,6 +40,7 @@ func main() {
 
 	r := chi.NewRouter()
 
+	r.Use(zipper.GzipMiddleware)
 	r.Use(logger.WithLogging(&log))
 
 	handler.RegisterRoutes(r)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,16 +2,27 @@ package main
 
 import (
 	"flag"
-	"log"
 	"net/http"
 	"os"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/kosta324/metrics.git/internal/handlers"
+	"github.com/kosta324/metrics.git/internal/logger"
 	"github.com/kosta324/metrics.git/internal/storage"
+	"go.uber.org/zap"
 )
 
+var log zap.SugaredLogger
+
 func main() {
+	logging, err := zap.NewDevelopment()
+	if err != nil {
+		panic(err)
+	}
+	defer logging.Sync()
+
+	log = *logging.Sugar()
+
 	addr := flag.String("a", "localhost:8080", "HTTP server address")
 
 	flag.Parse()
@@ -27,11 +38,14 @@ func main() {
 	handler := handlers.NewHandler(repo)
 
 	r := chi.NewRouter()
+
+	r.Use(logger.WithLogging(&log))
+
 	handler.RegisterRoutes(r)
 
-	log.Printf("Server running on %s", *addr)
-	err := http.ListenAndServe(*addr, r)
+	log.Info("Server running", zap.String("addr", *addr))
+	err = http.ListenAndServe(*addr, r)
 	if err != nil {
-		log.Fatalf("Server failed: %v", err)
+		log.Fatalf("Server failed: %v", zap.Error(err))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-chi/chi/v5 v5.2.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,62 @@
+package logger
+
+import (
+	"net/http"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type (
+	responseData struct {
+		status int
+		size   int
+	}
+
+	loggingResponseWriter struct {
+		http.ResponseWriter
+		responseData *responseData
+	}
+)
+
+func (r *loggingResponseWriter) Write(b []byte) (int, error) {
+	size, err := r.ResponseWriter.Write(b)
+	r.responseData.size += size
+	return size, err
+}
+
+func (r *loggingResponseWriter) WriteHeader(statusCode int) {
+	r.ResponseWriter.WriteHeader(statusCode)
+	r.responseData.status = statusCode
+}
+
+func WithLogging(log *zap.SugaredLogger) func(h http.Handler) http.Handler {
+	return func(h http.Handler) http.Handler {
+		logFn := func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			uri := r.RequestURI
+			method := r.Method
+			data := &responseData{
+				status: 0,
+				size:   0,
+			}
+			lw := loggingResponseWriter{
+				ResponseWriter: w,
+				responseData:   data,
+			}
+
+			h.ServeHTTP(&lw, r)
+			duration := time.Since(start)
+
+			log.Infoln(
+				"uri", uri,
+				"method", method,
+				"status", data.status,
+				"duration", duration,
+				"size", data.size,
+			)
+
+		}
+		return http.HandlerFunc(logFn)
+	}
+}

--- a/internal/zipper/zipper.go
+++ b/internal/zipper/zipper.go
@@ -1,0 +1,82 @@
+package zipper
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type gzipWriter struct {
+	http.ResponseWriter
+	Writer io.Writer
+}
+
+func (w gzipWriter) Write(b []byte) (int, error) {
+	return w.Writer.Write(b)
+}
+
+type wrappedResponseWriter struct {
+	http.ResponseWriter
+	body   bytes.Buffer
+	status int
+	wrote  bool
+}
+
+func (w *wrappedResponseWriter) WriteHeader(code int) {
+	if !w.wrote {
+		w.status = code
+		w.wrote = true
+	}
+}
+
+func (w *wrappedResponseWriter) Write(b []byte) (int, error) {
+	if !w.wrote {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.body.Write(b)
+}
+
+func GzipMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("Content-Encoding"), "gzip") {
+			gr, err := gzip.NewReader(r.Body)
+			if err != nil {
+				http.Error(w, "failed to decompress request", http.StatusBadRequest)
+				return
+			}
+			defer gr.Close()
+			r.Body = io.NopCloser(gr)
+		}
+
+		acceptsGzip := strings.Contains(r.Header.Get("Accept-Encoding"), "gzip")
+
+		if !acceptsGzip {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		wrw := &wrappedResponseWriter{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(wrw, r)
+
+		contentType := wrw.Header().Get("Content-Type")
+		if !(strings.HasPrefix(contentType, "application/json") || strings.HasPrefix(contentType, "text/html")) {
+			w.WriteHeader(wrw.status)
+			w.Write(wrw.body.Bytes())
+			return
+		}
+
+		w.Header().Set("Content-Encoding", "gzip")
+		w.WriteHeader(wrw.status)
+
+		gz, err := gzip.NewWriterLevel(w, gzip.BestSpeed)
+		if err != nil {
+			http.Error(w, "failed to init gzip writer", http.StatusInternalServerError)
+			return
+		}
+		defer gz.Close()
+
+		gz.Write(wrw.body.Bytes())
+	})
+}


### PR DESCRIPTION
Add gzip compression support for server and agent

- Agent now sends metrics using gzip compression with Content-Encoding: gzip
- Server detects and decompresses gzip-compressed request bodies when appropriate
- Server compresses responses with gzip if the client sets Accept-Encoding: gzip
- Compression applies only to responses with Content-Type: application/json or text/html