### PR TITLE
Iter9

### DIFF
--- a/cmd/agent/main_test.go
+++ b/cmd/agent/main_test.go
@@ -8,61 +8,43 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSendMetricJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+
+		var m Metrics
+		err = json.Unmarshal(body, &m)
+		assert.NoError(t, err)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(m)
+	}))
+	defer ts.Close()
+
+	serverAddress = &ts.URL
+
 	t.Run("send gauge metric", func(t *testing.T) {
-		value := 123.456
+		val := 123.456
 		metric := Metrics{
 			ID:    "TestGauge",
 			MType: "gauge",
-			Value: &value,
+			Value: &val,
 		}
-
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "/update/", r.URL.Path)
-			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
-			body, err := io.ReadAll(r.Body)
-			require.NoError(t, err)
-
-			var got Metrics
-			err = json.Unmarshal(body, &got)
-			require.NoError(t, err)
-
-			assert.Equal(t, metric.ID, got.ID)
-			assert.Equal(t, metric.MType, got.MType)
-			assert.Equal(t, *metric.Value, *got.Value)
-		}))
-		defer server.Close()
-
-		*serverAddress = server.URL[len("http://"):]
 		sendMetricJSON(metric)
 	})
 
 	t.Run("send counter metric", func(t *testing.T) {
-		count := int64(5)
+		delta := int64(42)
 		metric := Metrics{
 			ID:    "TestCounter",
 			MType: "counter",
-			Delta: &count,
+			Delta: &delta,
 		}
-
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "/update/", r.URL.Path)
-			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
-			body, err := io.ReadAll(r.Body)
-			require.NoError(t, err)
-			var got Metrics
-			err = json.Unmarshal(body, &got)
-			require.NoError(t, err)
-			assert.Equal(t, metric.ID, got.ID)
-			assert.Equal(t, metric.MType, got.MType)
-			assert.Equal(t, *metric.Delta, *got.Delta)
-		}))
-		defer server.Close()
-
-		*serverAddress = server.URL[len("http://"):]
 		sendMetricJSON(metric)
 	})
 }

--- a/cmd/agent/main_test.go
+++ b/cmd/agent/main_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendMetricJSON(t *testing.T) {
+	t.Run("send gauge metric", func(t *testing.T) {
+		value := 123.456
+		metric := Metrics{
+			ID:    "TestGauge",
+			MType: "gauge",
+			Value: &value,
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/update/", r.URL.Path)
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+
+			var got Metrics
+			err = json.Unmarshal(body, &got)
+			require.NoError(t, err)
+
+			assert.Equal(t, metric.ID, got.ID)
+			assert.Equal(t, metric.MType, got.MType)
+			assert.Equal(t, *metric.Value, *got.Value)
+		}))
+		defer server.Close()
+
+		*serverAddress = server.URL[len("http://"):]
+		sendMetricJSON(metric)
+	})
+
+	t.Run("send counter metric", func(t *testing.T) {
+		count := int64(5)
+		metric := Metrics{
+			ID:    "TestCounter",
+			MType: "counter",
+			Delta: &count,
+		}
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/update/", r.URL.Path)
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			var got Metrics
+			err = json.Unmarshal(body, &got)
+			require.NoError(t, err)
+			assert.Equal(t, metric.ID, got.ID)
+			assert.Equal(t, metric.MType, got.MType)
+			assert.Equal(t, *metric.Delta, *got.Delta)
+		}))
+		defer server.Close()
+
+		*serverAddress = server.URL[len("http://"):]
+		sendMetricJSON(metric)
+	})
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"net/http"
 	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/kosta324/metrics.git/internal/handlers"
@@ -13,7 +18,37 @@ import (
 	"go.uber.org/zap"
 )
 
+var (
+	addr          = flag.String("a", "localhost:8080", "HTTP server address")
+	storeInterval = flag.Int("i", 300, "Store interval in seconds (0 = sync write)")
+	filePath      = flag.String("f", "/tmp/metrics-db.json", "File storage path")
+	restore       = flag.Bool("r", true, "Restore metrics from file on startup")
+)
+
 var log zap.SugaredLogger
+
+func parseEnvOverrides() {
+	flag.Parse()
+	if len(flag.Args()) > 0 {
+		log.Fatalf("unknown arguments: %v", flag.Args())
+	}
+	if v := os.Getenv("ADDRESS"); v != "" {
+		*addr = v
+	}
+	if v := os.Getenv("STORE_INTERVAL"); v != "" {
+		if i, err := strconv.Atoi(v); err == nil {
+			*storeInterval = i
+		}
+	}
+	if v := os.Getenv("FILE_STORAGE_PATH"); v != "" {
+		*filePath = v
+	}
+	if v := os.Getenv("RESTORE"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			*restore = b
+		}
+	}
+}
 
 func main() {
 	logging, err := zap.NewDevelopment()
@@ -24,18 +59,30 @@ func main() {
 
 	log = *logging.Sugar()
 
-	addr := flag.String("a", "localhost:8080", "HTTP server address")
-
-	flag.Parse()
-	if len(flag.Args()) > 0 {
-		log.Fatalf("unknown arguments: %v", flag.Args())
-	}
-
-	if envAddr := os.Getenv("ADDRESS"); envAddr != "" {
-		*addr = envAddr
-	}
+	parseEnvOverrides()
 
 	repo := storage.NewMemStorage()
+
+	repo.SetFilePath(*filePath)
+
+	if *restore {
+		if err := repo.LoadFromFile(); err != nil {
+			log.Warnf("failed to load metrics from file: %v", err)
+		}
+	}
+
+	if *storeInterval > 0 {
+		go func() {
+			ticker := time.NewTicker(time.Duration(*storeInterval) * time.Second)
+			defer ticker.Stop()
+			for range ticker.C {
+				if err := repo.SaveToFile(); err != nil {
+					log.Errorf("failed to save metrics: %v", err)
+				}
+			}
+		}()
+	}
+
 	handler := handlers.NewHandler(repo)
 
 	r := chi.NewRouter()
@@ -45,9 +92,32 @@ func main() {
 
 	handler.RegisterRoutes(r)
 
-	log.Info("Server running", zap.String("addr", *addr))
-	err = http.ListenAndServe(*addr, r)
-	if err != nil {
-		log.Fatalf("Server failed: %v", zap.Error(err))
+	server := &http.Server{
+		Addr:    *addr,
+		Handler: r,
 	}
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		log.Info("Server running", zap.String("addr", *addr))
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("Server failed: %v", zap.Error(err))
+		}
+	}()
+
+	<-stop
+	log.Info("Shutting down server...")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := server.Shutdown(ctx); err != nil {
+		log.Fatalf("Server shutdown failed: %v", zap.Error(err))
+	}
+
+	if err := repo.SaveToFile(); err != nil {
+		log.Errorf("failed to save metrics on shutdown: %v", err)
+	}
+	log.Info("Server stopped gracefully")
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kosta324/metrics.git/internal/handlers"
 	"github.com/kosta324/metrics.git/internal/logger"
 	"github.com/kosta324/metrics.git/internal/storage"
+	"github.com/kosta324/metrics.git/internal/zipper"
 	"go.uber.org/zap"
 )
 
@@ -39,6 +40,7 @@ func main() {
 
 	r := chi.NewRouter()
 
+	r.Use(zipper.GzipMiddleware)
 	r.Use(logger.WithLogging(&log))
 
 	handler.RegisterRoutes(r)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,16 +2,27 @@ package main
 
 import (
 	"flag"
-	"log"
 	"net/http"
 	"os"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/kosta324/metrics.git/internal/handlers"
+	"github.com/kosta324/metrics.git/internal/logger"
 	"github.com/kosta324/metrics.git/internal/storage"
+	"go.uber.org/zap"
 )
 
+var log zap.SugaredLogger
+
 func main() {
+	logging, err := zap.NewDevelopment()
+	if err != nil {
+		panic(err)
+	}
+	defer logging.Sync()
+
+	log = *logging.Sugar()
+
 	addr := flag.String("a", "localhost:8080", "HTTP server address")
 
 	flag.Parse()
@@ -27,11 +38,14 @@ func main() {
 	handler := handlers.NewHandler(repo)
 
 	r := chi.NewRouter()
+
+	r.Use(logger.WithLogging(&log))
+
 	handler.RegisterRoutes(r)
 
-	log.Printf("Server running on %s", *addr)
-	err := http.ListenAndServe(*addr, r)
+	log.Info("Server running", zap.String("addr", *addr))
+	err = http.ListenAndServe(*addr, r)
 	if err != nil {
-		log.Fatalf("Server failed: %v", err)
+		log.Fatalf("Server failed: %v", zap.Error(err))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-chi/chi/v5 v5.2.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,62 @@
+package logger
+
+import (
+	"net/http"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type (
+	responseData struct {
+		status int
+		size   int
+	}
+
+	loggingResponseWriter struct {
+		http.ResponseWriter
+		responseData *responseData
+	}
+)
+
+func (r *loggingResponseWriter) Write(b []byte) (int, error) {
+	size, err := r.ResponseWriter.Write(b)
+	r.responseData.size += size
+	return size, err
+}
+
+func (r *loggingResponseWriter) WriteHeader(statusCode int) {
+	r.ResponseWriter.WriteHeader(statusCode)
+	r.responseData.status = statusCode
+}
+
+func WithLogging(log *zap.SugaredLogger) func(h http.Handler) http.Handler {
+	return func(h http.Handler) http.Handler {
+		logFn := func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			uri := r.RequestURI
+			method := r.Method
+			data := &responseData{
+				status: 0,
+				size:   0,
+			}
+			lw := loggingResponseWriter{
+				ResponseWriter: w,
+				responseData:   data,
+			}
+
+			h.ServeHTTP(&lw, r)
+			duration := time.Since(start)
+
+			log.Infoln(
+				"uri", uri,
+				"method", method,
+				"status", data.status,
+				"duration", duration,
+				"size", data.size,
+			)
+
+		}
+		return http.HandlerFunc(logFn)
+	}
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,8 +1,10 @@
 package storage
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 )
 
@@ -10,6 +12,9 @@ type Repository interface {
 	Add(metricType, name, value string) error
 	Get(metricType, name string) (string, error)
 	GetAll() map[string]string
+	SetFilePath(path string)
+	SaveToFile() error
+	LoadFromFile() error
 }
 
 type gauge float64
@@ -18,6 +23,7 @@ type counter int64
 type MemStorage struct {
 	Gauges   map[string]gauge
 	Counters map[string]counter
+	filePath string
 }
 
 func NewMemStorage() *MemStorage {
@@ -76,4 +82,68 @@ func (ms *MemStorage) GetAll() map[string]string {
 		result[k] = fmt.Sprintf("%d", v)
 	}
 	return result
+}
+
+func (ms *MemStorage) SetFilePath(path string) {
+	ms.filePath = path
+}
+
+func (ms *MemStorage) SaveToFile() error {
+	if ms.filePath == "" {
+		return errors.New("file path not set")
+	}
+	data := map[string]map[string]string{
+		"gauges":   {},
+		"counters": {},
+	}
+	for k, v := range ms.Gauges {
+		data["gauges"][k] = strconv.FormatFloat(float64(v), 'f', -1, 64)
+	}
+	for k, v := range ms.Counters {
+		data["counters"][k] = fmt.Sprintf("%d", v)
+	}
+
+	file, err := os.Create(ms.filePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	enc := json.NewEncoder(file)
+	return enc.Encode(data)
+}
+
+func (ms *MemStorage) LoadFromFile() error {
+	if ms.filePath == "" {
+		return errors.New("file path not set")
+	}
+	file, err := os.Open(ms.filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer file.Close()
+
+	var data map[string]map[string]string
+	if err := json.NewDecoder(file).Decode(&data); err != nil {
+		return err
+	}
+
+	for k, v := range data["gauges"] {
+		val, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			continue
+		}
+		ms.Gauges[k] = gauge(val)
+	}
+	for k, v := range data["counters"] {
+		val, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			continue
+		}
+		ms.Counters[k] = counter(val)
+	}
+	return nil
 }

--- a/internal/zipper/zipper.go
+++ b/internal/zipper/zipper.go
@@ -1,0 +1,82 @@
+package zipper
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type gzipWriter struct {
+	http.ResponseWriter
+	Writer io.Writer
+}
+
+func (w gzipWriter) Write(b []byte) (int, error) {
+	return w.Writer.Write(b)
+}
+
+type wrappedResponseWriter struct {
+	http.ResponseWriter
+	body   bytes.Buffer
+	status int
+	wrote  bool
+}
+
+func (w *wrappedResponseWriter) WriteHeader(code int) {
+	if !w.wrote {
+		w.status = code
+		w.wrote = true
+	}
+}
+
+func (w *wrappedResponseWriter) Write(b []byte) (int, error) {
+	if !w.wrote {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.body.Write(b)
+}
+
+func GzipMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("Content-Encoding"), "gzip") {
+			gr, err := gzip.NewReader(r.Body)
+			if err != nil {
+				http.Error(w, "failed to decompress request", http.StatusBadRequest)
+				return
+			}
+			defer gr.Close()
+			r.Body = io.NopCloser(gr)
+		}
+
+		acceptsGzip := strings.Contains(r.Header.Get("Accept-Encoding"), "gzip")
+
+		if !acceptsGzip {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		wrw := &wrappedResponseWriter{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(wrw, r)
+
+		contentType := wrw.Header().Get("Content-Type")
+		if !(strings.HasPrefix(contentType, "application/json") || strings.HasPrefix(contentType, "text/html")) {
+			w.WriteHeader(wrw.status)
+			w.Write(wrw.body.Bytes())
+			return
+		}
+
+		w.Header().Set("Content-Encoding", "gzip")
+		w.WriteHeader(wrw.status)
+
+		gz, err := gzip.NewWriterLevel(w, gzip.BestSpeed)
+		if err != nil {
+			http.Error(w, "failed to init gzip writer", http.StatusInternalServerError)
+			return
+		}
+		defer gz.Close()
+
+		gz.Write(wrw.body.Bytes())
+	})
+}


### PR DESCRIPTION
feat: add periodic metric persistence with configurable file storage and restore options

- Implemented automatic periodic saving of metrics to a file (default: every 300 seconds).
- Added support for loading previously saved metrics on server startup.
- Enabled graceful shutdown handling to persist metrics before exit.
- Introduced configuration via flags and environment variables.